### PR TITLE
Added ability to specify Pusher cluster by yaml config

### DIFF
--- a/app/assets/javascripts/sync.coffee
+++ b/app/assets/javascripts/sync.coffee
@@ -132,6 +132,7 @@ class RenderSync.Pusher extends RenderSync.Adapter
     opts.wsHost = RenderSyncConfig.pusher_ws_host if RenderSyncConfig.pusher_ws_host
     opts.wsPort = RenderSyncConfig.pusher_ws_port if RenderSyncConfig.pusher_ws_port
     opts.wssPort = RenderSyncConfig.pusher_wss_port if RenderSyncConfig.pusher_wss_port
+    opts.cluster = RenderSyncConfig.pusher_cluster if RenderSyncConfig.pusher_cluster
 
     @client = new window.Pusher(RenderSyncConfig.api_key, opts)
 

--- a/lib/generators/render_sync/templates/sync.yml
+++ b/lib/generators/render_sync/templates/sync.yml
@@ -14,6 +14,8 @@ development:
 #   auth_token: "YOUR_PUSHER_SECRET"
 #   adapter: "Pusher"
 #   async: true
+#   # optional if you use a non-default cluster
+#   #pusher_cluster: "ap1"
 
 # Disabled
 # development:

--- a/lib/render_sync.rb
+++ b/lib/render_sync.rb
@@ -52,6 +52,7 @@ module RenderSync
           pusher_ws_port: pusher_ws_port,
           pusher_wss_port: pusher_wss_port,
           pusher_encrypted: pusher_encrypted,
+          pusher_cluster: pusher_cluster,
           adapter: adapter
         }.reject { |k, v| v.nil? }.to_json
       end
@@ -131,6 +132,10 @@ module RenderSync
 
     def pusher_api_port
       config[:pusher_api_port]
+    end
+
+    def pusher_cluster
+      config[:pusher_cluster]
     end
 
     def pusher_ws_host

--- a/lib/render_sync/clients/pusher.rb
+++ b/lib/render_sync/clients/pusher.rb
@@ -19,6 +19,10 @@ module RenderSync
         if RenderSync.pusher_api_port
           ::Pusher.port = RenderSync.pusher_api_port
         end
+
+        if RenderSync.pusher_cluster
+          ::Pusher.cluster = RenderSync.pusher_cluster
+        end
       end
 
       def batch_publish(*args)


### PR DESCRIPTION
* Added `pusher_cluster` option to sync.yml and associated config code.  Allows users to specify a non-default cluster if required.
* Updated sync.yml to include an example of how to specify this if using Pusher.