### PR TITLE
Updated controller to use `before_action` as `before_filter` has been…

### DIFF
--- a/app/controllers/render_sync/refetches_controller.rb
+++ b/app/controllers/render_sync/refetches_controller.rb
@@ -1,8 +1,8 @@
 class RenderSync::RefetchesController < ApplicationController
 
-  before_filter :require_valid_request
-  before_filter :find_resource
-  before_filter :find_authorized_partial
+  before_action :require_valid_request
+  before_action :find_resource
+  before_action :find_authorized_partial
 
   def show
     render json: {


### PR DESCRIPTION
… removed from rails 5.1